### PR TITLE
Disable partial stacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ InventoryWizard is a powerful PaperMC plugin that brings intelligent, one-click 
 - **Smart categorization** - Items are grouped logically (weapons, tools, food, blocks, etc.)
 - **Hotbar optimization** - Weapons and tools prioritized for PvP/survival gameplay
 - **Stack consolidation** - Automatically combines partial stacks
+- **Configurable partial stack sorting** - Choose whether to sort only full stacks or include partial stacks (see config)
 - **Metadata preservation** - Maintains enchantments, names, and item data
 
 ### 🖱️ **Multiple Control Methods**
@@ -128,6 +129,11 @@ features:
   inventory-sorting: true
   hotbar-sorting: true
   show-messages: true
+  
+  # Allow sorting of partial stacks in chests (set false to only sort full stacks)
+  allow-partial-stacks-chest: true
+  # Allow sorting of partial stacks in player inventory (set false to only sort full stacks)
+  allow-partial-stacks-inventory: true
 
 # Hotbar sorting priorities (optimized for PvP/survival)
 hotbar-priorities:
@@ -138,6 +144,11 @@ hotbar-priorities:
   utility-items: 500  # Ender pearls, buckets, torches
   other: 999          # Everything else
 ```
+
+#### Partial Stack Sorting Behavior
+- `allow-partial-stacks-chest` and `allow-partial-stacks-inventory` control whether partial stacks are included in sorting for chests and player inventory, respectively.
+- **If set to `true`**: All items, including partial stacks, are sorted and consolidated as much as possible.
+- **If set to `false`**: Only full stacks are sorted. Any leftover partial stacks are left unsorted at the end of the inventory or chest.
 
 ## 📋 Sorting Categories
 
@@ -193,6 +204,9 @@ Contributions are welcome! Please feel free to submit pull requests, report bugs
 5. **Submit** a pull request
 
 ## 📜 Changelog
+
+### Version 1.0.2
+- ✨ **Configurable partial stack sorting** - Added `allow-partial-stacks-chest` and `allow-partial-stacks-inventory` config options. When set to false, only full stacks are sorted and any leftover partial stacks are left unsorted at the end.
 
 ### Version 1.0.1
 - 🔧 **Fixed control scheme** - Removed middle click, improved Shift+Right Click logic

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ InventoryWizard is a powerful PaperMC plugin that brings intelligent, one-click 
 - **Shift+Right Click** - Sort inventories, chests, and hotbar
 - **Double Click** - Alternative hotbar sorting
 - **Commands** - `/iwiz` for programmatic sorting
+- **Shift+Right Click in Hotbar Slot 4** - Cycle through sorting modes
 
 ### 🎒 **Comprehensive Coverage**
 - **Player Inventory** - Organize your main storage
@@ -40,6 +41,11 @@ InventoryWizard is a powerful PaperMC plugin that brings intelligent, one-click 
 - **Server**: PaperMC, Spigot, or compatible fork
 - **Java**: 17 or higher
 
+### Database
+- **H2 Database**: Embedded, no external setup required
+- **Storage**: `plugins/InventoryWizard/player_preferences.mv.db`
+- **Performance**: Optimized for servers with 1-10,000+ players
+
 ## 🎮 Usage Guide
 
 ### **Control Scheme Overview**
@@ -47,6 +53,7 @@ InventoryWizard is a powerful PaperMC plugin that brings intelligent, one-click 
 |--------|----------|-------------------|---------|
 | **Shift+Right Click** | Hotbar (slots 0-8) | `inventorywizard.all` | Sort inventory + hotbar |
 | **Shift+Right Click** | Hotbar (slots 0-8) | `inventorywizard.hotbar` | Sort hotbar only |
+| **Shift+Right Click** | Hotbar Slot 4 | `inventorywizard.use` | Cycle sorting modes |
 | **Shift+Right Click** | Main Inventory (slots 9-35) | `inventorywizard.inventory` | Sort main inventory |
 | **Shift+Right Click** | Chest | `inventorywizard.chest` | Sort chest contents |
 | **Double Click** | Hotbar (slots 0-8) | `inventorywizard.hotbar` | Sort hotbar only |
@@ -69,6 +76,13 @@ InventoryWizard is a powerful PaperMC plugin that brings intelligent, one-click 
 ### **Sorting Everything**
 - **Shift+Right Click** in your hotbar (slots 0-8) with `inventorywizard.all` permission
 - Both your inventory and hotbar will be sorted!
+
+### **Cycling Sorting Modes**
+- **Shift+Right Click** in hotbar slot 4 (middle slot) to cycle through sorting modes
+- **Default Mode**: Smart categorization by item type
+- **Alphabetical Mode**: Sort items alphabetically by name
+- **Stack-based Mode**: Group by item type, then sort by stack size (full stacks first)
+- Your preferred mode is saved and remembered for future sorting!
 
 ## 🧙‍♂️ Commands
 
@@ -150,9 +164,11 @@ hotbar-priorities:
 - **If set to `true`**: All items, including partial stacks, are sorted and consolidated as much as possible.
 - **If set to `false`**: Only full stacks are sorted. Any leftover partial stacks are left unsorted at the end of the inventory or chest.
 
-## 📋 Sorting Categories
+## 📋 Sorting Modes
 
-### **Inventory Sorting Order**
+### **Default Mode** (Smart Categorization)
+Items are sorted by logical categories:
+
 1. **Stone Types** - Stone, granite, cobblestone, deepslate, etc.
 2. **Earth Types** - Dirt, sand, gravel, clay, concrete, etc.
 3. **Wood Types** - Logs, planks, leaves, saplings
@@ -166,6 +182,12 @@ hotbar-priorities:
 11. **Transportation** - Boats, minecarts, saddles
 12. **Decoration** - Flowers, carpets, banners, etc.
 13. **Miscellaneous** - Everything else
+
+### **Alphabetical Mode**
+Items are sorted alphabetically by their material name (A-Z).
+
+### **Stack-based Mode**
+Items are grouped by type first, then sorted by stack size within each type. Full stacks appear before partial stacks of the same item.
 
 ### **Hotbar Sorting Order** (Optimized for PvP/Survival)
 1. **Weapons** - Combat items for quick access
@@ -204,9 +226,6 @@ Contributions are welcome! Please feel free to submit pull requests, report bugs
 5. **Submit** a pull request
 
 ## 📜 Changelog
-
-### Version 1.0.2
-- ✨ **Configurable partial stack sorting** - Added `allow-partial-stacks-chest` and `allow-partial-stacks-inventory` config options. When set to false, only full stacks are sorted and any leftover partial stacks are left unsorted at the end.
 
 ### Version 1.0.1
 - 🔧 **Fixed control scheme** - Removed middle click, improved Shift+Right Click logic

--- a/README.md
+++ b/README.md
@@ -227,6 +227,13 @@ Contributions are welcome! Please feel free to submit pull requests, report bugs
 
 ## 📜 Changelog
 
+### Version 1.1.0
+- ✨ **New Stack-based Sorting Mode** - Group items by type, then sort by stack size (full stacks first)
+  - 🔄 **Preserved Individual Stacks** - Partial stacks maintain their original sizes without combining
+- 📦 **Alphabetical Material Grouping** - Items grouped alphabetically by material name within stack-based mode
+- 🎯 **Enhanced Sorting Logic** - Improved stack size sorting (largest to smallest within each material type)
+- 🧙‍♂️ **Mode Cycling** - Easily switch between Default, Alphabetical, and Stack-based sorting modes
+
 ### Version 1.0.1
 - 🔧 **Fixed control scheme** - Removed middle click, improved Shift+Right Click logic
 - 🎯 **Enhanced hotbar sorting** - Priority-based permission system for combined sorting

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.inventorywizard</groupId>
     <artifactId>InventoryWizard</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -29,6 +29,12 @@
             <artifactId>paper-api</artifactId>
             <version>1.21.4-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>2.2.224</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 
@@ -63,6 +69,12 @@
                 <version>3.5.1</version>
                 <configuration>
                     <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.h2</pattern>
+                            <shadedPattern>com.inventorywizard.libs.h2</shadedPattern>
+                        </relocation>
+                    </relocations>
                 </configuration>
                 <executions>
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.inventorywizard</groupId>
     <artifactId>InventoryWizard</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.inventorywizard</groupId>
     <artifactId>InventoryWizard</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/com/inventorywizard/H2DatabaseManager.java
+++ b/src/main/java/com/inventorywizard/H2DatabaseManager.java
@@ -5,7 +5,6 @@ import org.bukkit.plugin.Plugin;
 
 import java.io.File;
 import java.sql.*;
-import java.util.UUID;
 import java.util.logging.Level;
 
 public class H2DatabaseManager {
@@ -165,13 +164,5 @@ public class H2DatabaseManager {
         
         return 0;
     }
-    
-    // Method to migrate from YAML if needed
-    public void migrateFromYaml(PlayerSortPreferences yamlPreferences) {
-        plugin.getLogger().info("Starting migration from YAML to H2...");
-        
-        // This would be implemented if we want to migrate existing YAML data
-        // For now, we'll start fresh with H2
-        plugin.getLogger().info("H2 database ready for new data!");
-    }
+
 } 

--- a/src/main/java/com/inventorywizard/H2DatabaseManager.java
+++ b/src/main/java/com/inventorywizard/H2DatabaseManager.java
@@ -1,0 +1,177 @@
+package com.inventorywizard;
+
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
+import java.io.File;
+import java.sql.*;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class H2DatabaseManager {
+    
+    private final Plugin plugin;
+    private final String dbPath;
+    private Connection connection;
+    
+    public H2DatabaseManager(Plugin plugin) {
+        this.plugin = plugin;
+        this.dbPath = new File(plugin.getDataFolder(), "player_preferences").getAbsolutePath();
+        initializeDatabase();
+        startH2Console();
+    }
+    
+    private void startH2Console() {
+        try {
+            // Start H2 console with basic parameters for better compatibility
+            int port = 8082;
+            String[] args = {"-web", "-webAllowOthers", "-webPort", String.valueOf(port)};
+            org.h2.tools.Server server = org.h2.tools.Server.createWebServer(args);
+            server.start();
+            
+            plugin.getLogger().info("H2 Console started at: http://localhost:" + port);
+            plugin.getLogger().info("Database URL: jdbc:h2:" + dbPath);
+            plugin.getLogger().info("Username: sa, Password: (empty)");
+            plugin.getLogger().info("Note: Console may only be accessible from localhost for security");
+            
+        } catch (Exception e) {
+            plugin.getLogger().warning("Could not start H2 console: " + e.getMessage());
+            plugin.getLogger().info("Database is still working - you can use /iwiz db to view stats");
+        }
+    }
+    
+    private void initializeDatabase() {
+        try {
+            // Create database directory if it doesn't exist
+            plugin.getDataFolder().mkdirs();
+            
+            // Load H2 driver explicitly (relocated in shaded JAR)
+            try {
+                Class.forName("org.h2.Driver");
+            } catch (ClassNotFoundException e) {
+                // Try the relocated version
+                Class.forName("com.inventorywizard.libs.h2.Driver");
+            }
+            
+            // Connect to H2 database with minimal configuration
+            String url = "jdbc:h2:" + dbPath;
+            connection = DriverManager.getConnection(url, "sa", "");
+            
+            // Create table if it doesn't exist
+            createTable();
+            
+            plugin.getLogger().info("H2 database initialized successfully!");
+            
+        } catch (ClassNotFoundException e) {
+            plugin.getLogger().log(Level.SEVERE, "H2 driver not found. Please ensure the plugin is properly built.", e);
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.SEVERE, "Failed to initialize H2 database: " + e.getMessage(), e);
+        }
+    }
+    
+    private void createTable() throws SQLException {
+        String sql = "CREATE TABLE IF NOT EXISTS player_preferences (" +
+                    "uuid VARCHAR(36) PRIMARY KEY, " +
+                    "sort_mode INT DEFAULT 0, " +
+                    "last_updated BIGINT DEFAULT 0)";
+        
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(sql);
+        }
+    }
+    
+    public PlayerSortPreferences.SortMode getPlayerSortMode(Player player) {
+        String uuid = player.getUniqueId().toString();
+        
+        String sql = "SELECT sort_mode FROM player_preferences WHERE uuid = ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, uuid);
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    int modeId = rs.getInt("sort_mode");
+                    return PlayerSortPreferences.SortMode.fromId(modeId);
+                }
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to get sort mode for player: " + player.getName(), e);
+        }
+        
+        return PlayerSortPreferences.SortMode.DEFAULT;
+    }
+    
+    public void setPlayerSortMode(Player player, PlayerSortPreferences.SortMode mode) {
+        String uuid = player.getUniqueId().toString();
+        long timestamp = System.currentTimeMillis();
+        
+        // Try INSERT first, if it fails due to duplicate key, use UPDATE
+        String insertSql = "INSERT INTO player_preferences (uuid, sort_mode, last_updated) VALUES (?, ?, ?)";
+        String updateSql = "UPDATE player_preferences SET sort_mode = ?, last_updated = ? WHERE uuid = ?";
+        
+        try (PreparedStatement insertStmt = connection.prepareStatement(insertSql)) {
+            insertStmt.setString(1, uuid);
+            insertStmt.setInt(2, mode.getId());
+            insertStmt.setLong(3, timestamp);
+            
+            insertStmt.executeUpdate();
+            
+        } catch (SQLException e) {
+            // If insert fails (duplicate key), try update
+            try (PreparedStatement updateStmt = connection.prepareStatement(updateSql)) {
+                updateStmt.setInt(1, mode.getId());
+                updateStmt.setLong(2, timestamp);
+                updateStmt.setString(3, uuid);
+                
+                updateStmt.executeUpdate();
+                
+            } catch (SQLException updateException) {
+                plugin.getLogger().log(Level.WARNING, "Failed to set sort mode for player: " + player.getName(), updateException);
+            }
+        }
+    }
+    
+    public PlayerSortPreferences.SortMode cyclePlayerSortMode(Player player) {
+        PlayerSortPreferences.SortMode currentMode = getPlayerSortMode(player);
+        PlayerSortPreferences.SortMode nextMode = currentMode.next();
+        setPlayerSortMode(player, nextMode);
+        return nextMode;
+    }
+    
+    public void close() {
+        if (connection != null) {
+            try {
+                connection.close();
+                plugin.getLogger().info("H2 database connection closed.");
+            } catch (SQLException e) {
+                plugin.getLogger().log(Level.WARNING, "Error closing database connection", e);
+            }
+        }
+    }
+    
+    // Utility method to get database statistics
+    public int getPlayerCount() {
+        String sql = "SELECT COUNT(*) FROM player_preferences";
+        
+        try (Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery(sql)) {
+            
+            if (rs.next()) {
+                return rs.getInt(1);
+            }
+        } catch (SQLException e) {
+            plugin.getLogger().log(Level.WARNING, "Failed to get player count", e);
+        }
+        
+        return 0;
+    }
+    
+    // Method to migrate from YAML if needed
+    public void migrateFromYaml(PlayerSortPreferences yamlPreferences) {
+        plugin.getLogger().info("Starting migration from YAML to H2...");
+        
+        // This would be implemented if we want to migrate existing YAML data
+        // For now, we'll start fresh with H2
+        plugin.getLogger().info("H2 database ready for new data!");
+    }
+} 

--- a/src/main/java/com/inventorywizard/InventorySorter.java
+++ b/src/main/java/com/inventorywizard/InventorySorter.java
@@ -389,10 +389,6 @@ public class InventorySorter {
     }
     
     // Alphabetical sorting method
-    private static List<ItemStack> sortAlphabetically(List<ItemStack> items) {
-        return sortAlphabetically(items, true);
-    }
-    
     private static List<ItemStack> sortAlphabetically(List<ItemStack> items, boolean allowPartialStacks) {
         Map<String, List<ItemStack>> groupedItems = groupItems(items);
         List<ItemStack> result = new ArrayList<>();

--- a/src/main/java/com/inventorywizard/InventoryWizardPlugin.java
+++ b/src/main/java/com/inventorywizard/InventoryWizardPlugin.java
@@ -4,11 +4,13 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class InventoryWizardPlugin extends JavaPlugin {
     
-    public static boolean allowPartialStacksChest = true;
-    public static boolean allowPartialStacksInventory = true;
+    private PlayerSortPreferences playerPreferences;
     
     @Override
     public void onEnable() {
+        // Initialize player preferences
+        playerPreferences = new PlayerSortPreferences(this);
+        
         // Register event listener
         getServer().getPluginManager().registerEvents(new SortListener(this), this);
         
@@ -20,20 +22,25 @@ public class InventoryWizardPlugin extends JavaPlugin {
         // Save default config
         saveDefaultConfig();
         
-        // Load config options
-        allowPartialStacksChest = getConfig().getBoolean("features.allow-partial-stacks-chest", true);
-        allowPartialStacksInventory = getConfig().getBoolean("features.allow-partial-stacks-inventory", true);
-        
         getLogger().info("InventoryWizard has awakened! ✨");
         getLogger().info("Commands: /iwiz [hotbar|inventory|all]");
         getLogger().info("Hotbar: Shift+Right-click in hotbar OR Double-click in hotbar");
         getLogger().info("Inventory: Shift+Right-click in main inventory");
         getLogger().info("Both: Shift+Right-click in hotbar (with all permission)");
+        getLogger().info("New: Shift+Right-click in hotbar slot 4 to cycle sorting modes!");
+        getLogger().info("Storage: H2 database for optimal performance! 🚀");
         getLogger().info("Cast your sorting spells wisely! 🧙‍♂️");
+    }
+    
+    public PlayerSortPreferences getPlayerPreferences() {
+        return playerPreferences;
     }
     
     @Override
     public void onDisable() {
+        if (playerPreferences != null) {
+            playerPreferences.close();
+        }
         getLogger().info("InventoryWizard is resting... The magic will return! ✨");
     }
 }

--- a/src/main/java/com/inventorywizard/InventoryWizardPlugin.java
+++ b/src/main/java/com/inventorywizard/InventoryWizardPlugin.java
@@ -4,6 +4,9 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class InventoryWizardPlugin extends JavaPlugin {
     
+    public static boolean allowPartialStacksChest = true;
+    public static boolean allowPartialStacksInventory = true;
+    
     @Override
     public void onEnable() {
         // Register event listener
@@ -16,6 +19,10 @@ public class InventoryWizardPlugin extends JavaPlugin {
         
         // Save default config
         saveDefaultConfig();
+        
+        // Load config options
+        allowPartialStacksChest = getConfig().getBoolean("features.allow-partial-stacks-chest", true);
+        allowPartialStacksInventory = getConfig().getBoolean("features.allow-partial-stacks-inventory", true);
         
         getLogger().info("InventoryWizard has awakened! ✨");
         getLogger().info("Commands: /iwiz [hotbar|inventory|all]");

--- a/src/main/java/com/inventorywizard/PlayerSortPreferences.java
+++ b/src/main/java/com/inventorywizard/PlayerSortPreferences.java
@@ -1,0 +1,93 @@
+package com.inventorywizard;
+
+import org.bukkit.entity.Player;
+
+public class PlayerSortPreferences {
+    
+    public enum SortMode {
+        DEFAULT(0, "Default"),
+        ALPHABETICAL(1, "Alphabetical"),
+        STACK_BASED(2, "Stack-based");
+        
+        private final int id;
+        private final String displayName;
+        
+        SortMode(int id, String displayName) {
+            this.id = id;
+            this.displayName = displayName;
+        }
+        
+        public int getId() {
+            return id;
+        }
+        
+        public String getDisplayName() {
+            return displayName;
+        }
+        
+        public static SortMode fromId(int id) {
+            for (SortMode mode : values()) {
+                if (mode.id == id) {
+                    return mode;
+                }
+            }
+            return DEFAULT;
+        }
+        
+        public SortMode next() {
+            int nextId = (this.id + 1) % values().length;
+            return fromId(nextId);
+        }
+    }
+    
+    private final InventoryWizardPlugin plugin;
+    private H2DatabaseManager database;
+    private boolean useH2 = true;
+    
+    public PlayerSortPreferences(InventoryWizardPlugin plugin) {
+        this.plugin = plugin;
+        try {
+            this.database = new H2DatabaseManager(plugin);
+            plugin.getLogger().info("Using H2 database for player preferences.");
+        } catch (Exception e) {
+            plugin.getLogger().warning("Failed to initialize H2 database, falling back to YAML storage.");
+            this.useH2 = false;
+            this.database = null;
+        }
+    }
+    
+    public SortMode getPlayerSortMode(Player player) {
+        if (useH2 && database != null) {
+            return database.getPlayerSortMode(player);
+        }
+        return SortMode.DEFAULT; // Fallback to default mode
+    }
+    
+    public void setPlayerSortMode(Player player, SortMode mode) {
+        if (useH2 && database != null) {
+            database.setPlayerSortMode(player, mode);
+        }
+        // In fallback mode, we don't persist preferences
+    }
+    
+    public SortMode cyclePlayerSortMode(Player player) {
+        if (useH2 && database != null) {
+            return database.cyclePlayerSortMode(player);
+        }
+        // In fallback mode, just cycle through modes without persistence
+        return SortMode.DEFAULT;
+    }
+    
+    public void close() {
+        if (database != null) {
+            database.close();
+        }
+    }
+    
+    public int getPlayerCount() {
+        if (useH2 && database != null) {
+            return database.getPlayerCount();
+        }
+        return 0;
+    }
+} 

--- a/src/main/java/com/inventorywizard/PlayerSortPreferences.java
+++ b/src/main/java/com/inventorywizard/PlayerSortPreferences.java
@@ -40,12 +40,10 @@ public class PlayerSortPreferences {
         }
     }
     
-    private final InventoryWizardPlugin plugin;
     private H2DatabaseManager database;
     private boolean useH2 = true;
     
     public PlayerSortPreferences(InventoryWizardPlugin plugin) {
-        this.plugin = plugin;
         try {
             this.database = new H2DatabaseManager(plugin);
             plugin.getLogger().info("Using H2 database for player preferences.");

--- a/src/main/java/com/inventorywizard/SortCommand.java
+++ b/src/main/java/com/inventorywizard/SortCommand.java
@@ -46,7 +46,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                     player.sendMessage("§c🧙‍♂️ Your magical privileges are insufficient for inventory sorting!");
                     return true;
                 }
-                InventorySorter.sortPlayerInventory(player);
+                InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.2f);
                 player.sendMessage("§a✨ Inventory magically organized!");
                 break;
@@ -57,7 +57,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                     player.sendMessage("§c🧙‍♂️ You need master-level permissions for complete inventory wizardry!");
                     return true;
                 }
-                InventorySorter.sortPlayerInventory(player);
+                InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
                 InventorySorter.sortHotbar(player);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.0f);
                 player.sendMessage("§b🧙‍♂️ Complete inventory transformation complete!");

--- a/src/main/java/com/inventorywizard/SortCommand.java
+++ b/src/main/java/com/inventorywizard/SortCommand.java
@@ -13,7 +13,10 @@ import java.util.stream.Collectors;
 
 public class SortCommand implements CommandExecutor, TabCompleter {
     
+    private final InventoryWizardPlugin plugin;
+    
     public SortCommand(InventoryWizardPlugin plugin) {
+        this.plugin = plugin;
     }
     
     @Override
@@ -63,6 +66,18 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                 player.sendMessage("§b🧙‍♂️ Complete inventory transformation complete!");
                 break;
                 
+            case "db":
+                if (!player.hasPermission("inventorywizard.admin")) {
+                    player.sendMessage("§c🧙‍♂️ You need admin permissions to view database information!");
+                    return true;
+                }
+                int playerCount = plugin.getPlayerPreferences().getPlayerCount();
+                player.sendMessage("§6🗄️ Database Statistics:");
+                player.sendMessage("§eTotal players with preferences: §f" + playerCount);
+                player.sendMessage("§eH2 Console: §fhttp://localhost:8082");
+                player.sendMessage("§eDatabase file: §fplugins/InventoryWizard/player_preferences.mv.db");
+                break;
+                
             default:
                 player.sendMessage("§e🧙‍♂️ InventoryWizard Usage: §f/iwiz [hotbar|inventory|all]");
                 player.sendMessage("§7Cast your sorting spells with: hotbar, inventory, or all");
@@ -75,8 +90,14 @@ public class SortCommand implements CommandExecutor, TabCompleter {
     @Override
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         if (args.length == 1) {
-            return Arrays.asList("hotbar", "inventory", "all")
-                    .stream()
+            List<String> options = Arrays.asList("hotbar", "inventory", "all");
+            
+            // Add db command for admins
+            if (sender.hasPermission("inventorywizard.admin")) {
+                options = Arrays.asList("hotbar", "inventory", "all", "db");
+            }
+            
+            return options.stream()
                     .filter(s -> s.toLowerCase().startsWith(args[0].toLowerCase()))
                     .collect(Collectors.toList());
         }

--- a/src/main/java/com/inventorywizard/SortCommand.java
+++ b/src/main/java/com/inventorywizard/SortCommand.java
@@ -22,7 +22,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
         if (!(sender instanceof Player)) {
-            sender.sendMessage("§c🧙‍♂️ The InventoryWizard's magic only works for players!");
+            sender.sendMessage("§c🧙✨ The InventoryWizard's magic only works for players!");
             return true;
         }
         
@@ -35,51 +35,54 @@ public class SortCommand implements CommandExecutor, TabCompleter {
             case "hotbar":
             case "hb":
                 if (!player.hasPermission("inventorywizard.hotbar")) {
-                    player.sendMessage("§c🧙‍♂️ You lack the magical permission to organize your hotbar!");
+                    player.sendMessage("§c🧙✨You lack the magical permission to organize your hotbar!");
                     return true;
                 }
-                InventorySorter.sortHotbar(player);
+                PlayerSortPreferences.SortMode mode = plugin.getPlayerPreferences().getPlayerSortMode(player);
+                InventorySorter.sortHotbar(player, mode);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.4f);
-                player.sendMessage("§6✨ Hotbar enchanted by the InventoryWizard!");
+                player.sendMessage("§6✨ Hotbar enchanted by the InventoryWizard! (" + mode.getDisplayName() + ")");
                 break;
                 
             case "inventory":
             case "inv":
                 if (!player.hasPermission("inventorywizard.inventory")) {
-                    player.sendMessage("§c🧙‍♂️ Your magical privileges are insufficient for inventory sorting!");
+                    player.sendMessage("§c🧙✨ Your magical privileges are insufficient for inventory sorting!");
                     return true;
                 }
-                InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
+                PlayerSortPreferences.SortMode invMode = plugin.getPlayerPreferences().getPlayerSortMode(player);
+                InventorySorter.sortPlayerInventory(player, invMode);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.2f);
-                player.sendMessage("§a✨ Inventory magically organized!");
+                player.sendMessage("§a✨ Inventory magically organized! (" + invMode.getDisplayName() + ")");
                 break;
                 
             case "all":
             case "both":
                 if (!player.hasPermission("inventorywizard.all")) {
-                    player.sendMessage("§c🧙‍♂️ You need master-level permissions for complete inventory wizardry!");
+                    player.sendMessage("§c🧙✨ You need master-level permissions for complete inventory wizardry!");
                     return true;
                 }
-                InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
-                InventorySorter.sortHotbar(player);
+                PlayerSortPreferences.SortMode allMode = plugin.getPlayerPreferences().getPlayerSortMode(player);
+                InventorySorter.sortPlayerInventory(player, allMode);
+                InventorySorter.sortHotbar(player, allMode);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.0f);
-                player.sendMessage("§b🧙‍♂️ Complete inventory transformation complete!");
+                player.sendMessage("§b🧙✨ Complete inventory transformation complete! (" + allMode.getDisplayName() + ")");
                 break;
                 
             case "db":
                 if (!player.hasPermission("inventorywizard.admin")) {
-                    player.sendMessage("§c🧙‍♂️ You need admin permissions to view database information!");
+                    player.sendMessage("§c🧙✨ You need admin permissions to view database information!");
                     return true;
                 }
                 int playerCount = plugin.getPlayerPreferences().getPlayerCount();
-                player.sendMessage("§6🗄️ Database Statistics:");
+                player.sendMessage("§6🗄️✨ Database Statistics:");
                 player.sendMessage("§eTotal players with preferences: §f" + playerCount);
                 player.sendMessage("§eH2 Console: §fhttp://localhost:8082");
                 player.sendMessage("§eDatabase file: §fplugins/InventoryWizard/player_preferences.mv.db");
                 break;
                 
             default:
-                player.sendMessage("§e🧙‍♂️ InventoryWizard Usage: §f/iwiz [hotbar|inventory|all]");
+                player.sendMessage("§e🧙✨ InventoryWizard Usage: §f/iwiz [hotbar|inventory|all]");
                 player.sendMessage("§7Cast your sorting spells with: hotbar, inventory, or all");
                 return true;
         }

--- a/src/main/java/com/inventorywizard/SortListener.java
+++ b/src/main/java/com/inventorywizard/SortListener.java
@@ -11,7 +11,12 @@ import org.bukkit.inventory.Inventory;
 
 public class SortListener implements Listener {
     
+    private final InventoryWizardPlugin plugin;
+    private final PlayerSortPreferences preferences;
+    
     public SortListener(InventoryWizardPlugin plugin) {
+        this.plugin = plugin;
+        this.preferences = plugin.getPlayerPreferences();
     }
     
     @EventHandler
@@ -37,18 +42,28 @@ public class SortListener implements Listener {
                 
                 event.setCancelled(true);
                 
+                // Special case: Slot 4 (middle hotbar slot) cycles sorting modes
+                if (event.getSlot() == 4) {
+                    PlayerSortPreferences.SortMode newMode = preferences.cyclePlayerSortMode(player);
+                    player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.6f);
+                    player.sendMessage("§e🔄 Sorting mode changed to: §6" + newMode.getDisplayName());
+                    return;
+                }
+                
                 // Check for combined sorting permission first
                 if (player.hasPermission("inventorywizard.all")) {
-                    InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
-                    InventorySorter.sortHotbar(player);
+                    PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                    InventorySorter.sortPlayerInventory(player, mode);
+                    InventorySorter.sortHotbar(player, mode);
                     player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.0f);
-                    player.sendMessage("§b🧙‍♂️ Complete inventory enchanted by the InventoryWizard!");
+                    player.sendMessage("§b🧙‍♂️ Complete inventory enchanted by the InventoryWizard! (" + mode.getDisplayName() + ")");
                 }
                 // Fall back to hotbar-only sorting
                 else if (player.hasPermission("inventorywizard.hotbar")) {
-                    InventorySorter.sortHotbar(player);
+                    PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                    InventorySorter.sortHotbar(player, mode);
                     player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.4f);
-                    player.sendMessage("§6✨ Hotbar organized by the InventoryWizard!");
+                    player.sendMessage("§6✨ Hotbar organized by the InventoryWizard! (" + mode.getDisplayName() + ")");
                 }
                 return;
             }
@@ -59,17 +74,22 @@ public class SortListener implements Listener {
             // Check if it's a chest inventory
             if (clickedInventory.getType() == InventoryType.CHEST && 
                 player.hasPermission("inventorywizard.chest")) {
-                InventorySorter.sortInventory(clickedInventory, InventoryWizardPlugin.allowPartialStacksChest);
+                
+                PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                InventorySorter.sortInventory(clickedInventory, mode);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.2f);
-                player.sendMessage("§a✨ Chest magically sorted!");
+                player.sendMessage("§a✨ Chest magically sorted! (" + mode.getDisplayName() + ")");
+                
             } 
             // Check if it's player inventory (main inventory slots, excluding hotbar)
             else if (clickedInventory.getType() == InventoryType.PLAYER && 
                      event.getSlot() > 8 && event.getSlot() < 36 &&
                      player.hasPermission("inventorywizard.inventory")) {
-                InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
+                
+                PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                InventorySorter.sortPlayerInventory(player, mode);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.2f);
-                player.sendMessage("§a✨ Inventory organized with wizard magic!");
+                player.sendMessage("§a✨ Inventory organized with wizard magic! (" + mode.getDisplayName() + ")");
             }
         }
         
@@ -87,9 +107,10 @@ public class SortListener implements Listener {
                 event.getSlot() >= 0 && event.getSlot() <= 8) {
                 
                 event.setCancelled(true);
-                InventorySorter.sortHotbar(player);
+                PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                InventorySorter.sortHotbar(player, mode);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.4f);
-                player.sendMessage("§6✨ Hotbar arranged by wizardry!");
+                player.sendMessage("§6✨ Hotbar arranged by wizardry! (" + mode.getDisplayName() + ")");
             }
         }
         

--- a/src/main/java/com/inventorywizard/SortListener.java
+++ b/src/main/java/com/inventorywizard/SortListener.java
@@ -39,7 +39,7 @@ public class SortListener implements Listener {
                 
                 // Check for combined sorting permission first
                 if (player.hasPermission("inventorywizard.all")) {
-                    InventorySorter.sortPlayerInventory(player);
+                    InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
                     InventorySorter.sortHotbar(player);
                     player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.0f);
                     player.sendMessage("§b🧙‍♂️ Complete inventory enchanted by the InventoryWizard!");
@@ -59,18 +59,15 @@ public class SortListener implements Listener {
             // Check if it's a chest inventory
             if (clickedInventory.getType() == InventoryType.CHEST && 
                 player.hasPermission("inventorywizard.chest")) {
-                
-                InventorySorter.sortInventory(clickedInventory);
+                InventorySorter.sortInventory(clickedInventory, InventoryWizardPlugin.allowPartialStacksChest);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.2f);
                 player.sendMessage("§a✨ Chest magically sorted!");
-                
             } 
             // Check if it's player inventory (main inventory slots, excluding hotbar)
             else if (clickedInventory.getType() == InventoryType.PLAYER && 
                      event.getSlot() > 8 && event.getSlot() < 36 &&
                      player.hasPermission("inventorywizard.inventory")) {
-                
-                InventorySorter.sortPlayerInventory(player);
+                InventorySorter.sortPlayerInventory(player, InventoryWizardPlugin.allowPartialStacksInventory);
                 player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.2f);
                 player.sendMessage("§a✨ Inventory organized with wizard magic!");
             }

--- a/src/main/java/com/inventorywizard/SortListener.java
+++ b/src/main/java/com/inventorywizard/SortListener.java
@@ -11,11 +11,9 @@ import org.bukkit.inventory.Inventory;
 
 public class SortListener implements Listener {
     
-    private final InventoryWizardPlugin plugin;
     private final PlayerSortPreferences preferences;
     
     public SortListener(InventoryWizardPlugin plugin) {
-        this.plugin = plugin;
         this.preferences = plugin.getPlayerPreferences();
     }
     
@@ -56,7 +54,7 @@ public class SortListener implements Listener {
                     InventorySorter.sortPlayerInventory(player, mode);
                     InventorySorter.sortHotbar(player, mode);
                     player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.0f);
-                    player.sendMessage("§b🧙‍♂️ Complete inventory enchanted by the InventoryWizard! (" + mode.getDisplayName() + ")");
+                    player.sendMessage("§b🧙✨ Complete inventory enchanted by the InventoryWizard! (" + mode.getDisplayName() + ")");
                 }
                 // Fall back to hotbar-only sorting
                 else if (player.hasPermission("inventorywizard.hotbar")) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -22,6 +22,11 @@ features:
   
   # Show magical messages when sorting
   show-messages: true
+  
+  # Allow sorting of partial stacks in chests (set false to only sort full stacks)
+  allow-partial-stacks-chest: true
+  # Allow sorting of partial stacks in player inventory (set false to only sort full stacks)
+  allow-partial-stacks-inventory: true
 
 # Hotbar sorting priorities (optimized for PvP/survival wizardry)
 hotbar-priorities:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,5 +42,5 @@ messages:
   chest-sorted: "§a✨ Chest magically sorted!"
   inventory-sorted: "§a✨ Inventory organized with wizard magic!"
   hotbar-sorted: "§6✨ Hotbar arranged by wizardry!"
-  all-sorted: "§b🧙‍♂️ Complete inventory enchanted by the InventoryWizard!"
-  no-permission: "§c🧙‍♂️ You lack the magical permission for this spell!"
+  all-sorted: "§b🧙✨ Complete inventory enchanted by the InventoryWizard!"
+  no-permission: "§c🧙✨ You lack the magical permission for this spell!"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,8 +1,8 @@
 name: InventoryWizard
-version: 1.0.2
+version: 1.1.0
 main: com.inventorywizard.InventoryWizardPlugin
 api-version: "1.21"
-description: Magically sort chests and inventories with intuitive clicks
+description: Magically sort chests and inventories with H2 database performance and cycling sorting modes
 author: VanishingTacos
 website: https://github.com/VanishingTacos/InventoryWizard
 
@@ -22,6 +22,9 @@ permissions:
   inventorywizard.all:
     description: Allows sorting everything at once
     default: true
+  inventorywizard.admin:
+    description: Allows viewing database information and admin features
+    default: op
 
 commands:
   iwiz:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: InventoryWizard
-version: 1.0.1
+version: 1.0.2
 main: com.inventorywizard.InventoryWizardPlugin
 api-version: "1.21"
 description: Magically sort chests and inventories with intuitive clicks


### PR DESCRIPTION
Added `allow-partial-stacks-chest` and `allow-partial-stacks-inventory` config options. When set to false, only full stacks are sorted and any leftover partial stacks are left unsorted at the end