### PR TITLE
Add Option to Configure Rate-Limiting on a Per-Player Basis

### DIFF
--- a/src/main/java/com/inventorywizard/H2DatabaseManager.java
+++ b/src/main/java/com/inventorywizard/H2DatabaseManager.java
@@ -17,7 +17,7 @@ public class H2DatabaseManager {
     
     public H2DatabaseManager(Plugin plugin) {
         this.plugin = plugin;
-        this.dbPath = new File(plugin.getDataFolder(), "player_preferences").getAbsolutePath();
+        this.dbPath = new File(plugin.getDataFolder(), "player_data").getAbsolutePath();
         this.credentials = new DatabaseCredentials((InventoryWizardPlugin) plugin);
         this.errorHandler = new ErrorHandler(plugin.getLogger());
         initializeDatabase();
@@ -70,9 +70,10 @@ public class H2DatabaseManager {
     
     private void createTable() throws SQLException {
         // Use parameterized query for table creation to prevent SQL injection
-        String sql = "CREATE TABLE IF NOT EXISTS player_preferences (" +
+        String sql = "CREATE TABLE IF NOT EXISTS player_data (" +
                     "uuid VARCHAR(36) PRIMARY KEY, " +
                     "sort_mode INT DEFAULT 0, " +
+                    "rate_limit_enabled BOOLEAN DEFAULT TRUE, " +
                     "last_updated BIGINT DEFAULT 0)";
         
         try (Statement stmt = connection.createStatement()) {
@@ -80,28 +81,70 @@ public class H2DatabaseManager {
             plugin.getLogger().info("Database table created/verified successfully");
         } catch (SQLException e) {
             errorHandler.logError(
-                ErrorHandler.getDatabaseErrorMessage("table creation"),
+             ErrorHandler.getDatabaseErrorMessage("table creation"),
                 "Failed to create database table",
                 e
             );
             throw e;
         }
+        
+        // run database migrations if needed
+        migrateDatabase();
     }
     
-    public PlayerSortPreferences.SortMode getPlayerSortMode(Player player) {
+    private void migrateDatabase() throws SQLException { 
+        // ensure table is named player_data (rename if needed for migration)
+        renameTableIfNeeded();
+        // add rate_limit_enabled column if it doesn't exist (for migration)
+        addRateLimitColumnIfMissing();
+    }
+    
+    private void renameTableIfNeeded() throws SQLException {
+        try {
+            // check if old table exists
+            DatabaseMetaData meta = connection.getMetaData();
+            ResultSet tables = meta.getTables(null, null, "PLAYER_PREFERENCES", new String[]{"TABLE"});
+            if (tables.next()) {
+                // old table exists, rename it
+                String renameSql = "ALTER TABLE player_preferences RENAME TO player_data";
+                try (Statement stmt = connection.createStatement()) {
+                    stmt.execute(renameSql);
+                    plugin.getLogger().info("Renamed table from player_preferences to player_data");
+                }
+            }
+        } catch (SQLException e) {
+            // table might not exist or already renamed - log but don't fail
+            plugin.getLogger().info("Table rename check completed (table may already be named correctly)");
+        }
+    }
+    
+    private void addRateLimitColumnIfMissing() throws SQLException {
+        try {
+            String alterSql = "ALTER TABLE player_data ADD COLUMN IF NOT EXISTS rate_limit_enabled BOOLEAN DEFAULT TRUE";
+            try (Statement alterStmt = connection.createStatement()) {
+                alterStmt.execute(alterSql);
+                plugin.getLogger().info("Ensured rate_limit_enabled column exists in database");
+            }
+        } catch (SQLException e) {
+            // column might already exist, or other SQL error - log but don't fail
+            plugin.getLogger().info("Rate limit column migration completed (column may already exist)");
+        }
+    }
+    
+    public PlayerDataManager.SortMode getPlayerSortMode(Player player) {
         // Validate input parameters
         if (!InputValidator.validatePlayer(player)) {
             errorHandler.logValidationError("player object", player.getName(), "null or invalid");
-            return PlayerSortPreferences.SortMode.DEFAULT;
+            return PlayerDataManager.SortMode.DEFAULT;
         }
         
         String uuid = InputValidator.validateUUID(player.getUniqueId().toString());
         if (uuid == null) {
             errorHandler.logValidationError("UUID format", player.getName(), player.getUniqueId().toString());
-            return PlayerSortPreferences.SortMode.DEFAULT;
+            return PlayerDataManager.SortMode.DEFAULT;
         }
         
-        String sql = "SELECT sort_mode FROM player_preferences WHERE uuid = ?";
+        String sql = "SELECT sort_mode FROM player_data WHERE uuid = ?";
         
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setString(1, uuid);
@@ -110,17 +153,17 @@ public class H2DatabaseManager {
                 if (rs.next()) {
                     int modeId = rs.getInt("sort_mode");
                     int validatedModeId = InputValidator.validateSortModeId(modeId);
-                    return PlayerSortPreferences.SortMode.fromId(validatedModeId);
+                    return PlayerDataManager.SortMode.fromId(validatedModeId);
                 }
             }
         } catch (SQLException e) {
             errorHandler.logDatabaseError("get sort mode", player.getName(), e);
         }
         
-        return PlayerSortPreferences.SortMode.DEFAULT;
+        return PlayerDataManager.SortMode.DEFAULT;
     }
     
-    public void setPlayerSortMode(Player player, PlayerSortPreferences.SortMode mode) {
+    public void setPlayerSortMode(Player player, PlayerDataManager.SortMode mode) {
         // Validate all input parameters
         InputValidator.ValidationResult validation = InputValidator.validateDatabaseInput(player, mode, System.currentTimeMillis());
         
@@ -134,8 +177,8 @@ public class H2DatabaseManager {
         long timestamp = validation.getTimestamp();
         
         // Try INSERT first, if it fails due to duplicate key, use UPDATE
-        String insertSql = "INSERT INTO player_preferences (uuid, sort_mode, last_updated) VALUES (?, ?, ?)";
-        String updateSql = "UPDATE player_preferences SET sort_mode = ?, last_updated = ? WHERE uuid = ?";
+        String insertSql = "INSERT INTO player_data (uuid, sort_mode, last_updated) VALUES (?, ?, ?)";
+        String updateSql = "UPDATE player_data SET sort_mode = ?, last_updated = ? WHERE uuid = ?";
         
         try (PreparedStatement insertStmt = connection.prepareStatement(insertSql)) {
             insertStmt.setString(1, uuid);
@@ -159,9 +202,9 @@ public class H2DatabaseManager {
         }
     }
     
-    public PlayerSortPreferences.SortMode cyclePlayerSortMode(Player player) {
-        PlayerSortPreferences.SortMode currentMode = getPlayerSortMode(player);
-        PlayerSortPreferences.SortMode nextMode = currentMode.next();
+    public PlayerDataManager.SortMode cyclePlayerSortMode(Player player) {
+        PlayerDataManager.SortMode currentMode = getPlayerSortMode(player);
+        PlayerDataManager.SortMode nextMode = currentMode.next();
         setPlayerSortMode(player, nextMode);
         return nextMode;
     }
@@ -230,6 +273,73 @@ public class H2DatabaseManager {
         plugin.getLogger().info("=================================");
     }
     
+    public boolean getPlayerRateLimitEnabled(Player player) {
+        if (!InputValidator.validatePlayer(player)) {
+            errorHandler.logValidationError("player object", player.getName(), "null or invalid");
+            return true; // default to enabled
+        }
+        
+        String uuid = InputValidator.validateUUID(player.getUniqueId().toString());
+        if (uuid == null) {
+            errorHandler.logValidationError("UUID format", player.getName(), player.getUniqueId().toString());
+            return true;
+        }
+        
+        String sql = "SELECT rate_limit_enabled FROM player_data WHERE uuid = ?";
+        
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, uuid);
+            
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getBoolean("rate_limit_enabled");
+                }
+            }
+        } catch (SQLException e) {
+            errorHandler.logDatabaseError("get rate limit enabled", player.getName(), e);
+        }
+        
+        return true; // default to enabled
+    }
+    
+    public void setPlayerRateLimitEnabled(Player player, boolean enabled) {
+        if (!InputValidator.validatePlayer(player)) {
+            errorHandler.logValidationError("player object", player.getName(), "null or invalid");
+            return;
+        }
+        
+        String uuid = InputValidator.validateUUID(player.getUniqueId().toString());
+        if (uuid == null) {
+            errorHandler.logValidationError("UUID format", player.getName(), player.getUniqueId().toString());
+            return;
+        }
+        
+        long timestamp = System.currentTimeMillis();
+        
+        // try INSERT first, if it fails due to duplicate key, use UPDATE
+        String insertSql = "INSERT INTO player_data (uuid, rate_limit_enabled, last_updated) VALUES (?, ?, ?)";
+        String updateSql = "UPDATE player_data SET rate_limit_enabled = ?, last_updated = ? WHERE uuid = ?";
+        
+        try (PreparedStatement insertStmt = connection.prepareStatement(insertSql)) {
+            insertStmt.setString(1, uuid);
+            insertStmt.setBoolean(2, enabled);
+            insertStmt.setLong(3, timestamp);
+            
+            insertStmt.executeUpdate();
+            
+        } catch (SQLException e) {
+            // if insert fails (duplicate key), try update
+            try (PreparedStatement updateStmt = connection.prepareStatement(updateSql)) {
+                updateStmt.setBoolean(1, enabled);
+                updateStmt.setLong(2, timestamp);
+                updateStmt.setString(3, uuid);
+                
+                updateStmt.executeUpdate();
+                
+            } catch (SQLException updateException) {
+                errorHandler.logDatabaseError("set rate limit enabled", player.getName(), updateException);
+            }
+        }
+    }
 
-
-} 
+}

--- a/src/main/java/com/inventorywizard/InputValidator.java
+++ b/src/main/java/com/inventorywizard/InputValidator.java
@@ -112,7 +112,7 @@ public class InputValidator {
      * @return ValidationResult containing validated parameters or error message
      */
     public static ValidationResult validateDatabaseInput(org.bukkit.entity.Player player, 
-                                                       PlayerSortPreferences.SortMode mode, 
+                                                       PlayerDataManager.SortMode mode, 
                                                        long timestamp) {
         // Validate player
         if (!validatePlayer(player)) {

--- a/src/main/java/com/inventorywizard/InventorySorter.java
+++ b/src/main/java/com/inventorywizard/InventorySorter.java
@@ -11,18 +11,18 @@ import java.util.*;
 public class InventorySorter {
     
     public static void sortInventory(Inventory inventory) {
-        sortInventory(inventory, PlayerSortPreferences.SortMode.DEFAULT, true);
+        sortInventory(inventory, PlayerDataManager.SortMode.DEFAULT, true);
     }
     
-    public static void sortInventory(Inventory inventory, PlayerSortPreferences.SortMode mode) {
+    public static void sortInventory(Inventory inventory, PlayerDataManager.SortMode mode) {
         sortInventory(inventory, mode, true);
     }
     
     public static void sortInventory(Inventory inventory, boolean allowPartialStacks) {
-        sortInventory(inventory, PlayerSortPreferences.SortMode.DEFAULT, allowPartialStacks);
+        sortInventory(inventory, PlayerDataManager.SortMode.DEFAULT, allowPartialStacks);
     }
     
-    public static void sortInventory(Inventory inventory, PlayerSortPreferences.SortMode mode, boolean allowPartialStacks) {
+    public static void sortInventory(Inventory inventory, PlayerDataManager.SortMode mode, boolean allowPartialStacks) {
         List<ItemStack> items = new ArrayList<>();
         
         // Collect all items from the inventory
@@ -58,18 +58,18 @@ public class InventorySorter {
     }
     
     public static void sortPlayerInventory(Player player) {
-        sortPlayerInventory(player, PlayerSortPreferences.SortMode.DEFAULT, true);
+        sortPlayerInventory(player, PlayerDataManager.SortMode.DEFAULT, true);
     }
     
-    public static void sortPlayerInventory(Player player, PlayerSortPreferences.SortMode mode) {
+    public static void sortPlayerInventory(Player player, PlayerDataManager.SortMode mode) {
         sortPlayerInventory(player, mode, true);
     }
     
     public static void sortPlayerInventory(Player player, boolean allowPartialStacks) {
-        sortPlayerInventory(player, PlayerSortPreferences.SortMode.DEFAULT, allowPartialStacks);
+        sortPlayerInventory(player, PlayerDataManager.SortMode.DEFAULT, allowPartialStacks);
     }
     
-    public static void sortPlayerInventory(Player player, PlayerSortPreferences.SortMode mode, boolean allowPartialStacks) {
+    public static void sortPlayerInventory(Player player, PlayerDataManager.SortMode mode, boolean allowPartialStacks) {
         PlayerInventory inventory = player.getInventory();
         List<ItemStack> items = new ArrayList<>();
         
@@ -111,10 +111,10 @@ public class InventorySorter {
     }
     
     public static void sortHotbar(Player player) {
-        sortHotbar(player, PlayerSortPreferences.SortMode.DEFAULT);
+        sortHotbar(player, PlayerDataManager.SortMode.DEFAULT);
     }
     
-    public static void sortHotbar(Player player, PlayerSortPreferences.SortMode mode) {
+    public static void sortHotbar(Player player, PlayerDataManager.SortMode mode) {
         PlayerInventory inventory = player.getInventory();
         List<ItemStack> items = new ArrayList<>();
         

--- a/src/main/java/com/inventorywizard/InventoryWizardPlugin.java
+++ b/src/main/java/com/inventorywizard/InventoryWizardPlugin.java
@@ -4,16 +4,16 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 public class InventoryWizardPlugin extends JavaPlugin {
     
-    private PlayerSortPreferences playerPreferences;
+    private PlayerDataManager playerDataManager;
     private RateLimiter rateLimiter;
     
     @Override
     public void onEnable() {
-        // Initialize rate limiter
-        rateLimiter = new RateLimiter();
+        // Initialize player data manager
+        playerDataManager = new PlayerDataManager(this);
         
-        // Initialize player preferences
-        playerPreferences = new PlayerSortPreferences(this);
+        // Initialize rate limiter
+        rateLimiter = new RateLimiter(playerDataManager);
         
         // Register event listener
         getServer().getPluginManager().registerEvents(new SortListener(this), this);
@@ -37,8 +37,8 @@ public class InventoryWizardPlugin extends JavaPlugin {
         getLogger().info("Cast your sorting spells wisely! 🧙‍♂️");
     }
     
-    public PlayerSortPreferences getPlayerPreferences() {
-        return playerPreferences;
+    public PlayerDataManager getPlayerDataManager() {
+        return playerDataManager;
     }
     
     public RateLimiter getRateLimiter() {
@@ -47,8 +47,8 @@ public class InventoryWizardPlugin extends JavaPlugin {
     
     @Override
     public void onDisable() {
-        if (playerPreferences != null) {
-            playerPreferences.close();
+        if (playerDataManager != null) {
+            playerDataManager.close();
         }
         getLogger().info("InventoryWizard is resting... The magic will return! ✨");
     }

--- a/src/main/java/com/inventorywizard/PlayerDataManager.java
+++ b/src/main/java/com/inventorywizard/PlayerDataManager.java
@@ -2,7 +2,7 @@ package com.inventorywizard;
 
 import org.bukkit.entity.Player;
 
-public class PlayerSortPreferences {
+public class PlayerDataManager {
     
     public enum SortMode {
         DEFAULT(0, "Default"),
@@ -43,7 +43,7 @@ public class PlayerSortPreferences {
     private H2DatabaseManager database;
     private boolean useH2 = true;
     
-    public PlayerSortPreferences(InventoryWizardPlugin plugin) {
+    public PlayerDataManager(InventoryWizardPlugin plugin) {
         try {
             this.database = new H2DatabaseManager(plugin);
             plugin.getLogger().info("Using H2 database for player preferences.");
@@ -75,6 +75,20 @@ public class PlayerSortPreferences {
         // In fallback mode, just cycle through modes without persistence
         return SortMode.DEFAULT;
     }
+
+    public boolean isPlayerRateLimited(Player player) {
+        if (useH2 && database != null) {
+            return database.getPlayerRateLimitEnabled(player);
+        }
+        return true; // default to rate limited
+    }
+    
+    public void setPlayerRateLimited(Player player, boolean rateLimited) {
+        if (useH2 && database != null) {
+            database.setPlayerRateLimitEnabled(player, rateLimited);
+        }
+        // In fallback mode, we don't persist preferences
+    }
     
     public void close() {
         if (database != null) {
@@ -93,10 +107,9 @@ public class PlayerSortPreferences {
      * Regenerate database credentials for security purposes
      */
     public void regenerateCredentials() {
-        if (database != null) {
+        if (useH2 && database != null) {
             database.regenerateCredentials();
         }
     }
-    
 
 } 

--- a/src/main/java/com/inventorywizard/RateLimiter.java
+++ b/src/main/java/com/inventorywizard/RateLimiter.java
@@ -15,11 +15,17 @@ public class RateLimiter {
     private final Map<UUID, Long> lastSortTime = new ConcurrentHashMap<>();
     private final Map<UUID, Integer> sortCount = new ConcurrentHashMap<>();
     
+    private final PlayerDataManager playerDataManager;
+    
     // Configuration
     private static final long MIN_SORT_INTERVAL_MS = 10000; // 10 seconds between sorts
     private static final int MAX_SORTS_PER_MINUTE = 10; // Max 10 sorts per minute
     private static final long RESET_INTERVAL_MS = 60000; // Reset counter every minute
     private static final long MAX_SORT_DURATION_MS = 5000; // Max 5 seconds per sort operation
+    
+    public RateLimiter(PlayerDataManager playerDataManager) {
+        this.playerDataManager = playerDataManager;
+    }
     
     /**
      * Check if a player can perform a sort operation
@@ -29,6 +35,10 @@ public class RateLimiter {
     public boolean canSort(Player player) {
         if (player == null) {
             return false;
+        }
+        
+        if (!playerDataManager.isPlayerRateLimited(player)) {
+            return true; // no rate limiting for this player
         }
         
         UUID playerId = player.getUniqueId();

--- a/src/main/java/com/inventorywizard/SortCommand.java
+++ b/src/main/java/com/inventorywizard/SortCommand.java
@@ -49,7 +49,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                 }
                 
                 long startTime = System.currentTimeMillis();
-                PlayerSortPreferences.SortMode mode = plugin.getPlayerPreferences().getPlayerSortMode(player);
+                PlayerDataManager.SortMode mode = plugin.getPlayerDataManager().getPlayerSortMode(player);
                 InventorySorter.sortHotbar(player, mode);
                 
                 // Record the sort operation
@@ -81,7 +81,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                 }
                 
                 long invStartTime = System.currentTimeMillis();
-                PlayerSortPreferences.SortMode invMode = plugin.getPlayerPreferences().getPlayerSortMode(player);
+                PlayerDataManager.SortMode invMode = plugin.getPlayerDataManager().getPlayerSortMode(player);
                 InventorySorter.sortPlayerInventory(player, invMode);
                 
                 // Record the sort operation
@@ -113,7 +113,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                 }
                 
                 long allStartTime = System.currentTimeMillis();
-                PlayerSortPreferences.SortMode allMode = plugin.getPlayerPreferences().getPlayerSortMode(player);
+                PlayerDataManager.SortMode allMode = plugin.getPlayerDataManager().getPlayerSortMode(player);
                 InventorySorter.sortPlayerInventory(player, allMode);
                 InventorySorter.sortHotbar(player, allMode);
                 
@@ -134,7 +134,7 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                     player.sendMessage("§c🧙✨ " + ErrorHandler.getPermissionErrorMessage());
                     return true;
                 }
-                plugin.getPlayerPreferences().regenerateCredentials();
+                plugin.getPlayerDataManager().regenerateCredentials();
                 player.sendMessage("§a🔐 Database credentials regenerated successfully!");
                 player.sendMessage("§7New credentials have been saved to the configuration file.");
                 break;
@@ -160,6 +160,36 @@ public class SortCommand implements CommandExecutor, TabCompleter {
                 player.sendMessage("§a⏰ Rate limiting reset for your account!");
                 break;
                 
+            case "rate-limit-enabled":
+                if (!player.hasPermission("inventorywizard.admin")) {
+                    player.sendMessage("§c🧙✨ " + ErrorHandler.getPermissionErrorMessage());
+                    return true;
+                }
+                if (args.length < 3) {
+                    player.sendMessage("§e🧙✨ Usage: §f/iwiz rate-limit-enabled <playername> <on|off>");
+                    return true;
+                }
+                String targetPlayerName = args[1];
+                String state = args[2].toLowerCase();
+                boolean enableRateLimit = state.equals("on");
+                if (!state.equals("on") && !state.equals("off")) {
+                    player.sendMessage("§c🧙✨ Invalid state. Use 'on' or 'off'.");
+                    return true;
+                }
+                
+                // find the target player
+                Player targetPlayer = plugin.getServer().getPlayer(targetPlayerName);
+                if (targetPlayer == null) {
+                    player.sendMessage("§c🧙✨ Player '" + targetPlayerName + "' is not online.");
+                    return true;
+                }
+                
+                // set the rate limit preference
+                plugin.getPlayerDataManager().setPlayerRateLimited(targetPlayer, enableRateLimit);
+                player.sendMessage("§a🛡️ Rate limiting " + (enableRateLimit ? "enabled" : "disabled") + " for " + targetPlayer.getName() + ".");
+                targetPlayer.sendMessage("§6🛡️ Rate limiting for InventoryWizard sorting has been " + (enableRateLimit ? "enabled" : "disabled") + " by an admin.");
+                break;
+                
 
                 
             default:
@@ -178,13 +208,30 @@ public class SortCommand implements CommandExecutor, TabCompleter {
             
             // Add admin commands for admins
             if (sender.hasPermission("inventorywizard.admin")) {
-                options = Arrays.asList("hotbar", "inventory", "all", "regen-credentials", "rate-limit", "reset-rate-limit");
+                options = Arrays.asList("hotbar", "inventory", "all", "regen-credentials", "rate-limit", "reset-rate-limit", "rate-limit-enabled");
             }
             
             return options.stream()
                     .filter(s -> s.toLowerCase().startsWith(args[0].toLowerCase()))
                     .collect(Collectors.toList());
         }
+        
+        // tab completion for rate-limit-enabled subcommand
+        if (args.length == 2 && args[0].equalsIgnoreCase("rate-limit-enabled") && sender.hasPermission("inventorywizard.admin")) {
+            // suggest online player names
+            return plugin.getServer().getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(name -> name.toLowerCase().startsWith(args[1].toLowerCase()))
+                    .collect(Collectors.toList());
+        }
+        
+        // tab completion for rate-limit-enabled state
+        if (args.length == 3 && args[0].equalsIgnoreCase("rate-limit-enabled") && sender.hasPermission("inventorywizard.admin")) {
+            return Arrays.asList("on", "off").stream()
+                    .filter(s -> s.startsWith(args[2].toLowerCase()))
+                    .collect(Collectors.toList());
+        }
+        
         return null;
     }
 }

--- a/src/main/java/com/inventorywizard/SortListener.java
+++ b/src/main/java/com/inventorywizard/SortListener.java
@@ -11,11 +11,11 @@ import org.bukkit.inventory.Inventory;
 
 public class SortListener implements Listener {
     
-    private final PlayerSortPreferences preferences;
+    private final PlayerDataManager preferences;
     private final InventoryWizardPlugin plugin;
     
     public SortListener(InventoryWizardPlugin plugin) {
-        this.preferences = plugin.getPlayerPreferences();
+        this.preferences = plugin.getPlayerDataManager();
         this.plugin = plugin;
     }
     
@@ -44,7 +44,7 @@ public class SortListener implements Listener {
                 
                 // Special case: Slot 4 (middle hotbar slot) cycles sorting modes
                 if (event.getSlot() == 4) {
-                    PlayerSortPreferences.SortMode newMode = preferences.cyclePlayerSortMode(player);
+                    PlayerDataManager.SortMode newMode = preferences.cyclePlayerSortMode(player);
                     player.playSound(player.getLocation(), Sound.UI_BUTTON_CLICK, 0.5f, 1.6f);
                     player.sendMessage("§e🔄 Sorting mode changed to: §6" + newMode.getDisplayName());
                     return;
@@ -63,7 +63,7 @@ public class SortListener implements Listener {
                 
                 // Check for combined sorting permission first
                 if (player.hasPermission("inventorywizard.all")) {
-                    PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                    PlayerDataManager.SortMode mode = preferences.getPlayerSortMode(player);
                     InventorySorter.sortPlayerInventory(player, mode);
                     InventorySorter.sortHotbar(player, mode);
                     
@@ -80,7 +80,7 @@ public class SortListener implements Listener {
                 }
                 // Fall back to hotbar-only sorting
                 else if (player.hasPermission("inventorywizard.hotbar")) {
-                    PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                    PlayerDataManager.SortMode mode = preferences.getPlayerSortMode(player);
                     InventorySorter.sortHotbar(player, mode);
                     
                     // Record the sort operation
@@ -114,7 +114,7 @@ public class SortListener implements Listener {
                 }
                 
                 long startTime = System.currentTimeMillis();
-                PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                PlayerDataManager.SortMode mode = preferences.getPlayerSortMode(player);
                 InventorySorter.sortInventory(clickedInventory, mode);
                 
                 // Record the sort operation
@@ -144,7 +144,7 @@ public class SortListener implements Listener {
                 }
                 
                 long startTime = System.currentTimeMillis();
-                PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                PlayerDataManager.SortMode mode = preferences.getPlayerSortMode(player);
                 InventorySorter.sortPlayerInventory(player, mode);
                 
                 // Record the sort operation
@@ -185,7 +185,7 @@ public class SortListener implements Listener {
                 }
                 
                 long startTime = System.currentTimeMillis();
-                PlayerSortPreferences.SortMode mode = preferences.getPlayerSortMode(player);
+                PlayerDataManager.SortMode mode = preferences.getPlayerSortMode(player);
                 InventorySorter.sortHotbar(player, mode);
                 
                 // Record the sort operation


### PR DESCRIPTION
Firstly, this is a nice plugin, and I appreciate the flexibility it offers compared to other chest-sorting plugins. That said, the rate-limiting feature seems to be designed for large servers with many concurrent players making sort requests. In my use case, I only play on my server with a handful of others online at a time, and being rate-limited tends to get in the way more than it helps.

After reviewing the README, it seems that rate limiting was intended to be configurable on a per-player basis, but this doesn’t actually seem to be the case. I wanted to suggest adding this feature.

**Note:** A good portion of this PR is related to convention changes (e.g., `PlayerSortPreferences` -> `PlayerDataManager`), which could have likely been split into a separate PR, but hopefully these changes are still straightforward to review. I made these because the db seems to do more than just track user preferences, it also handles admin controls, and I think it makes sense to reflect that in the naming.

**Summary of changes:**
- `H2DatabaseManager.java`: added db migration helper function, convention changes
- `PlayerDataManager.java`: added setter and getter for rate-limit enablement
- `RateLimiter.java`: added a check if player is rate-limited before blocking user actions
- `SortCommand.java`: added new `rate-limit-enabled` commands

**Mostly convention changes:**
- `SortListener.java`
- `InputValidator.java`
- `InventorySorter.java`
- `InventoryWizardPlugin.java`